### PR TITLE
Add in gulpTaskOption hooks, handle dependencies better

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ As show in the example above, there are options that you can pass while register
 | autoprefixerOptions | true | We use [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer) to help simplify our LESS/CSS, feel free to pass in your options to autoprefixer as defined by the module itself |
 | tscOptions | true | Options for [gulp-typescript](https://github.com/ivogabe/gulp-typescript) |
 | deps | true | A map of src globs to dest paths for the build process to copy over before build time |
+| gulpTaskOptions | true | A map of gulp task names to additional tasks that should be ran as pre-reqs to the gulp task |
 
 ## 4 flavors of gulp tasks
 You can register all, or just a subset of the available gulp tasks.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # [gulp](https://github.com/gulpjs/gulp)-onejs-build
+[![Dependency Status](https://david-dm.org/OneJSToolkit/gulp-onejs-build.svg)](https://david-dm.org/OneJSToolkit/gulp-onejs-build)
+
 A set of handy gulp tasks to build, test, and release your OneJS project.
 
 ## How to use

--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ module.exports = {
             },
             deps: {
                 // OneJS files that will need to be copied during build process
-                oneJsDts: 'bower_components/onejs/dist/amd/*.d.ts',
-                oneJsJs: 'bower_components/onejs/dist/amd/*.js',
-                typings: 'typings/**/*.d.ts',
+                'bower_components/onejs/dist/amd/*.d.ts': 'temp/',
+                'bower_components/onejs/dist/amd/*.js': 'app/onejs/',
+                'typings/**/*.d.ts': 'temp/',
             },
             dist: {
                 // Distributable structure

--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ module.exports = {
                     root: 'app-min/'
                 }
             },
-            deps: {},
+            deps: {
+                // OneJS files that will need to be copied during build process
+                oneJsDts: 'bower_components/onejs/dist/amd/*.d.ts',
+                oneJsJs: 'bower_components/onejs/dist/amd/*.js',
+            },
             dist: {
                 // Distributable structure
                 root: 'dist/',
@@ -49,11 +53,6 @@ module.exports = {
                 ],
                 npmPackage: 'package.json',
                 bowerPackage: 'bower.json'
-            },
-            onejsFiles: {
-                // OneJS files that will need to be copied during build process
-                dts: 'bower_components/onejs/dist/amd/*.ts',
-                js: 'bower_components/onejs/dist/amd/*.js'
             },
             release: {
                 // These are temp directories that are only used when

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
                 // OneJS files that will need to be copied during build process
                 oneJsDts: 'bower_components/onejs/dist/amd/*.d.ts',
                 oneJsJs: 'bower_components/onejs/dist/amd/*.js',
+                typings: 'typings/**/*.d.ts',
             },
             dist: {
                 // Distributable structure

--- a/package.json
+++ b/package.json
@@ -36,10 +36,11 @@
     "gulp-typescript": "^2.3.0",
     "gulp-uglifyjs": "^0.5.0",
     "gulp-util": "^3.0.1",
-    "inquirer": "0.8.0",
+    "inquirer": "^0.8.0",
     "lodash": "^2.4.1",
     "onejs-compiler": "^1.1.60",
     "semver": "^4.1.0",
+    "through2": "^0.6.3",
     "tslint": "^1.0.1"
   },
   "devDependencies": {

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -31,7 +31,7 @@ module.exports = function(options) {
     });
 
     /** Removes all built files EXCEPT dist directory for gulp watch purposes */
-    gulp.task('clean', _.union(['clean'], gulpTaskOptions['clean']), function(cb) {
+    gulp.task('clean', _.union(gulpTaskOptions['clean']), function(cb) {
         del([
             paths.temp.root,
             paths.app.root,

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -56,11 +56,6 @@ module.exports = function(options) {
         cb();
     });
 
-    gulp.task('copy-typings-dts', _.union(['clean'], gulpTaskOptions['copy-typings-dts']), function() {
-        return gulp.src(paths.typings.glob)
-            .pipe(gulp.dest(paths.temp.root));
-    });
-
     /** Runs LESS compiler, auto-prefixer, and uglify, then creates js modules and outputs to temp folder */
     gulp.task('build-less', _.union(['clean'], gulpTaskOptions['build-less']), function() {
         return gulp.src(paths.src.lessGlob)
@@ -100,7 +95,7 @@ module.exports = function(options) {
     });
 
     /** Runs the basic pre-processing steps before compilation */
-    gulp.task('build-app-preprocess', _.union(['build-templates', 'copy-typescript', 'build-less', 'copy-typings-dts', 'copy-app-deps'], gulpTaskOptions['build-app-preprocess']));
+    gulp.task('build-app-preprocess', _.union(['build-templates', 'copy-typescript', 'build-less', 'copy-app-deps'], gulpTaskOptions['build-app-preprocess']));
 
     /** Runs the TypeScript amd compiler over your application .ts files */
     gulp.task('build-app-amd', _.union(['build-app-preprocess'], gulpTaskOptions['build-app-amd']), function() {

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -15,6 +15,7 @@ module.exports = function(options) {
     var tslint = require('gulp-tslint');
     var gutil = require('gulp-util');
     var path = require('path');
+    var through = require('through2');
 
     var gulp = options.gulp;
     var paths = options.paths;

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -81,6 +81,9 @@ module.exports = function(options) {
      * Taks dealing with git, or writing back the package/bower.json files
      * need to be synchronous, ergo the callback usage or sync versions
      * of the node fs methods.
+     *
+     * Do not allow gulpTaskOptions within the release section or else it will
+     * probably break some assumptions we make about release tasks.
      */
 
     /** Temporarily copies the built folder to a temp dir so it will persist

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -23,7 +23,7 @@ module.exports = function(options) {
     var newVersion;
 
     /** Creates a minified version of your application */
-    gulp.task('build-app-minify', ['build-app-amd'], function() {
+    gulp.task('build-app-minify', _.union(['build-app-amd'], gulpTaskOptions['build-app-minify']), function() {
         return gulp.src([paths.app.jsGlob])
             .pipe(uglify())
             .pipe(size({
@@ -34,14 +34,14 @@ module.exports = function(options) {
     });
 
     /** Copies the minified static files to your application path */
-    gulp.task('copy-minified-static-files', ['clean'], function() {
+    gulp.task('copy-minified-static-files', _.union(['clean'], gulpTaskOptions['copy-minified-static-files']), function() {
         return gulp.src(paths.staticFiles.js)
             .pipe(uglify())
             .pipe(gulp.dest(paths.app.min.root));
     });
 
     /** Creates the amd distributable directory */
-    gulp.task('build-dist-amd', ['build-app-preprocess'], function() {
+    gulp.task('build-dist-amd', _.union(['build-app-preprocess'], gulpTaskOptions['build-dist-amd']), function() {
         var tsResult = gulp.src(paths.temp.srcGlob)
             // Allow tscOption overrides, but ensure that we're targeting amd
             .pipe(tsc(_.merge(tscOptions, {module: 'amd', declarationFiles: true})));
@@ -51,7 +51,7 @@ module.exports = function(options) {
     });
 
     /** Creates the commonjs distributable directory */
-    gulp.task('build-dist-commonjs', ['build-app-preprocess'], function() {
+    gulp.task('build-dist-commonjs', _.union(['build-app-preprocess'], gulpTaskOptions['build-dist-commonjs']), function() {
         var tsResult = gulp.src(paths.temp.srcGlob)
             // Allow tscOption overrides, but ensure that we're targeting commonjs
             .pipe(tsc(_.merge(tscOptions, {module: 'commonjs', declarationFiles: true})));
@@ -60,20 +60,20 @@ module.exports = function(options) {
         return tsResult.js.pipe(gulp.dest(paths.dist.commonjs));
     });
 
-    gulp.task('copy-dist-css', ['build-app-preprocess'], function() {
+    gulp.task('copy-dist-css', _.union(['build-app-preprocess'], gulpTaskOptions['copy-dist-css']), function() {
         return gulp.src(paths.app.cssGlob)
             .pipe(gulp.dest(paths.dist.amd))
             .pipe(gulp.dest(paths.dist.commonjs));
     });
 
-    gulp.task('copy-dist-templates', ['build-app-preprocess'], function() {
+    gulp.task('copy-dist-templates', _.union(['build-app-preprocess'], gulpTaskOptions['copy-dist-templates']), function() {
         return gulp.src(paths.app.htmlGlob)
             .pipe(gulp.dest(paths.dist.amd))
             .pipe(gulp.dest(paths.dist.commonjs));
     })
 
     /** Creates both dist flavors */
-    gulp.task('build-dist', ['build-dist-commonjs', 'build-dist-amd', 'copy-dist-css', 'copy-dist-templates']);
+    gulp.task('build-dist', _.union(['build-dist-commonjs', 'build-dist-amd', 'copy-dist-css', 'copy-dist-templates'], gulpTaskOptions['build-dist']));
 
     /**
      * This next section of tasks are intentionally a bunch of small tasks
@@ -215,5 +215,5 @@ module.exports = function(options) {
     });
 
     /** Builds the minified version of your app */
-    gulp.task('build-minify', ['build-app-minify', 'copy-minified-static-files']);
+    gulp.task('build-minify', _.union(['build-app-minify', 'copy-minified-static-files'], gulpTaskOptions['build-minify']));
 };

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -18,6 +18,7 @@ module.exports = function(options) {
     var paths = options.paths;
     var rootDir = options.rootDir;
     var tscOptions = options.tscOptions;
+    var gulpTaskOptions = options.gulpTaskOptions;
 
     var bumpType;
     var newVersion;
@@ -167,8 +168,17 @@ module.exports = function(options) {
         });
     });
 
+    /** Sets the local dist to be exactly what the server dist branch is
+        in order to avoid conflicts, or people forgetting to pull first */
+    gulp.task('reset-dist', ['checkout-dist'], function(cb) {
+        git.reset('origin/HEAD', {args:'--hard'}, function (err) {
+            if (err) { return cb(err); }
+            cb();
+        });
+    });
+
     /** Copies the dist files to their rightful location */
-    gulp.task('copy-dist-bits', ['checkout-dist'], function() {
+    gulp.task('copy-dist-bits', ['reset-dist'], function() {
         return gulp.src(paths.release.distGlob)
             .pipe(gulp.dest(paths.dist.root));
     });
@@ -214,7 +224,7 @@ module.exports = function(options) {
     /** The main task for bumping versions and publishing to dist branch */
     gulp.task('release', ['checkout-master'], function() {
         gutil.log(gutil.colors.green('Version bumped!'));
-        gutil.log(gutil.colors.green('Please run `git push --follow-tags` and `git push --tags` and `npm/bower publish` to make updates available.'));
+        gutil.log(gutil.colors.green('Please run `git push` and `git push --tags` and `npm/bower publish` to make updates available.'));
     });
 
     /** Builds the minified version of your app */

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -13,16 +13,16 @@ module.exports = function(options) {
     var tscOptions = options.tscOptions;
     var tsLintOptions = options.tsLintOptions;
 
-    gulp.task('build-test-preprocess', ['clean'], function() {
+    gulp.task('build-test-preprocess', _.union(['clean'], gulpTaskOptions(['build-test-preprocess'])), function() {
         return gulp.src(paths.test.glob)
             .pipe(gulp.dest(paths.temp.test))
             .pipe(tslint(tsLintOptions))
             .pipe(tslint.report('verbose'));
     });
 
-    gulp.task('build-test', ['build-test-preprocess', 'build-app-preprocess', 'build-app-amd', 'copy-app-deps', 'copy-onejs-js']);
+    gulp.task('build-test', _.union(['build-test-preprocess', 'build-app-preprocess', 'build-app-amd', 'copy-app-deps'], gulpTaskOptions(['build-test'])));
 
-    gulp.task('test', ['build-test', 'build-app'], function (done) {
+    gulp.task('test', _.union(['build-test', 'build-app'], gulpTaskOptions(['test'])), function (done) {
         karma.start(_.merge({
             configFile: rootDir + '/karma.conf.js',
             singleRun: true

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -27,6 +27,8 @@ module.exports = function(options) {
         karma.start(_.merge({
             configFile: rootDir + '/karma.conf.js',
             singleRun: true
-        }, karmaOptions), done);
+        }, karmaOptions), karmaOptions['doneCb'] ? function(resultcode) {
+            done(karmaOptions['doneCb'](resultcode))
+        } : done);
     });
 }

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -12,17 +12,18 @@ module.exports = function(options) {
     var karmaOptions = options.karmaOptions;
     var tscOptions = options.tscOptions;
     var tsLintOptions = options.tsLintOptions;
+    var gulpTaskOptions = options.gulpTaskOptions;
 
-    gulp.task('build-test-preprocess', _.union(['clean'], gulpTaskOptions(['build-test-preprocess'])), function() {
+    gulp.task('build-test-preprocess', _.union(['clean'], gulpTaskOptions['build-test-preprocess']), function() {
         return gulp.src(paths.test.glob)
             .pipe(gulp.dest(paths.temp.test))
             .pipe(tslint(tsLintOptions))
             .pipe(tslint.report('verbose'));
     });
 
-    gulp.task('build-test', _.union(['build-test-preprocess', 'build-app-preprocess', 'build-app-amd', 'copy-app-deps'], gulpTaskOptions(['build-test'])));
+    gulp.task('build-test', _.union(['build-test-preprocess', 'build-app-preprocess', 'build-app-amd', 'copy-app-deps'], gulpTaskOptions['build-test']));
 
-    gulp.task('test', _.union(['build-test', 'build-app'], gulpTaskOptions(['test'])), function (done) {
+    gulp.task('test', _.union(['build-test', 'build-app'], gulpTaskOptions['test']), function (done) {
         karma.start(_.merge({
             configFile: rootDir + '/karma.conf.js',
             singleRun: true


### PR DESCRIPTION
- Add in gulpTaskOption hooks to add dependencies to predefined tasks
- Handle OneJS dep copying in a more generic fashion
- Add David DM for dependency management badge
- Fix up the release task
